### PR TITLE
Fixes for Includes

### DIFF
--- a/include/cstone/primitives/warpscan.cuh
+++ b/include/cstone/primitives/warpscan.cuh
@@ -34,6 +34,7 @@
 #include <type_traits>
 
 #include "cstone/cuda/gpu_config.cuh"
+#include "cstone/primitives/clz.hpp"
 
 namespace cstone
 {
@@ -41,10 +42,6 @@ namespace cstone
 //! @brief there's no int overload for min in AMD ROCM
 __device__ __forceinline__ int imin(int a, int b) { return a < b ? a : b; }
 __device__ __forceinline__ unsigned imin(unsigned a, unsigned b) { return a < b ? a : b; }
-
-__device__ __forceinline__ int countLeadingZeros(uint32_t x) { return __clz(x); }
-
-__device__ __forceinline__ int countLeadingZeros(uint64_t x) { return __clzll(x); }
 
 __device__ __forceinline__ uint32_t reverseBits(uint32_t x) { return __brev(x); }
 

--- a/include/cstone/tree/definitions.h
+++ b/include/cstone/tree/definitions.h
@@ -25,7 +25,8 @@
 
 #pragma once
 
-#include <cstdint>
+#include <cassert>
+#include <type_traits>
 #include "cstone/cuda/annotation.hpp"
 
 #include "cstone/primitives/stl.hpp"


### PR DESCRIPTION
- Fixes includes in `definitions.h`
- Re-uses `countLeadingZeros` from `clz.hpp` in `warpscan.cuh`.

Context for the second ‘fix’: The previous double-definition can lead to strange code generation issues when `warpscan.cuh` is included before `clz.hpp`: For whatever reason, the generated host code seems to try to call the device function (at least according to cuda-gdb, did not look at the assembly code to see what really happens). This leads to an immediate exit of the program with exit code 1 but without any error message. Might be a compiler bug, as I guess there should be a compile-time error, but did not investigate further.